### PR TITLE
Make custom cover option visible in game settings

### DIFF
--- a/app/src/main/res/drawable/image_24px.xml
+++ b/app/src/main/res/drawable/image_24px.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/app/src/main/res/layout/dialog_game_settings.xml
+++ b/app/src/main/res/layout/dialog_game_settings.xml
@@ -51,14 +51,36 @@
             android:textColor="@color/md_theme_tertiaryFixedDim"
             android:layout_marginBottom="8dp"/>
 
-        <!-- Custom Cover Button -->
+        <!-- Cover art management -->
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Cover Art"
+            android:textStyle="bold"
+            android:textSize="16sp"
+            android:textColor="@color/brand_primary"
+            android:paddingBottom="8dp"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Set, replace, or remove the cover shown in the game grid."
+            android:textSize="12sp"
+            android:textColor="@color/md_theme_tertiaryFixedDim"
+            android:layout_marginBottom="8dp"/>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/btn_set_custom_cover"
             style="@style/PSX2.ElevatedTransparentButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Set Custom Cover"
-            android:layout_marginBottom="16dp" />
+            android:text="Manage Custom Cover"
+            android:textColor="@android:color/white"
+            android:layout_marginBottom="16dp"
+            app:icon="@drawable/image_24px"
+            app:iconGravity="textStart"
+            app:iconPadding="12dp"
+            app:iconTint="@android:color/white" />
 
         <!-- Graphics Settings -->
         <TextView


### PR DESCRIPTION
## Summary
- add a dedicated cover art section and clearer button copy to the game settings dialog
- include an image icon so the custom cover control is visually discoverable

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224ff7c7348326b03bee1c421babc2)